### PR TITLE
fix(front-end): fix always matching a range

### DIFF
--- a/front-end/src/components/routes/components/TableEditor.js
+++ b/front-end/src/components/routes/components/TableEditor.js
@@ -187,12 +187,12 @@ class TableEditor extends React.Component {
         if(event.target.value.trim() === "") {
             results[key].roll = "";
         } else {
-            const alphaRegEx = /[A-Z][a-z]/,
-                  tempArr = event.target.value.split("-");
+            const alphaRegEx = /[A-Z][a-z]/;
+            const tempArr = event.target.value.split("-");
 
             if(alphaRegEx.test(event.target.value)) {
                 return;
-            } else if(tempArr > 1 || event.target.value.includes("-")) {
+            } else if(tempArr.length > 1 || event.target.value.includes("-")) {
                 results[key].roll = event.target.value;
             } else {
                 results[key].roll = parseInt(event.target.value, 10);


### PR DESCRIPTION
Turns out that `tempArr > 1` will pretty much always match... probably wanted `tempArr.length > 1` instead, no?